### PR TITLE
0.0.8 init and set sqlfiles status as executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,11 @@ Install sqldog globally so that it can be used on commandline anywhere.
 ```
 sqldog init
 ```
-Some files are executed before and it's ok to ***set*** them as ***executed*** within initialization.
+Some files are executed before and it's ok to ***set*** them as ***executed*** state within initialization.
 
 ```
 sqldog init -se
 ```
-
-
-
 
 * Config options
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Install sqldog globally so that it can be used on commandline anywhere.
 ```
 sqldog init
 ```
+Some files are executed before and it's ok to ***set*** them as ***executed*** within initialization.
+
+```
+sqldog init -se
+```
+
+
+
+
 * Config options
 ```
 sqldog config
@@ -42,7 +51,7 @@ sqldog exec -f sql_file_name
 ```
 sqldog status
 ```
-* Sqldog walks around here and there to detect not tracked files, and removed files
+* Sqldog ***walks*** around here and there to detect not tracked files, and removed files
 ```
 sqldog walk
 ```

--- a/actions.js
+++ b/actions.js
@@ -33,6 +33,10 @@ exports.init = function() {
 	setup.init();
 }
 
+exports.initse = function() {
+	setup.init(true);
+}
+
 exports.config = function (){
 	setup.config();
 }

--- a/dispatcher.js
+++ b/dispatcher.js
@@ -2,6 +2,7 @@ var actions = require('./actions');
 
 
 const INIT = 'init';
+const INIT_SE = 'init_se';
 const CONFIG = 'config';
 const EXEC = 'ex';
 const EXEC_F = 'exf';
@@ -10,6 +11,7 @@ const WALK = 'walk';
 
 //command pattern
 var init = /^init$/,
+	init_se = /^init -se$/,
 	config = /^config$/,
 	exec = /^exec ([\d\D]+.sql)$/,
 	exec_f = /^exec -f ([\d\D]+.sql)$/,
@@ -18,6 +20,7 @@ var init = /^init$/,
 
 var routes = [
 	{pattern:init,action:INIT},
+	{pattern:init_se,action:INIT_SE},
 	{pattern:config,action:CONFIG},
 	{pattern:exec,action:EXEC},
 	{pattern:exec_f,action:EXEC_F},
@@ -50,6 +53,9 @@ exports.handle = function(cmd) {
 	switch (route.action) {
 		case INIT:
 			actions.init();
+			break;
+		case INIT_SE:
+			actions.initse();
 			break;
 		case CONFIG:
 			actions.config();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqldog",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "watch sql files",
   "main": "index.js",
   "scripts": {

--- a/setup.js
+++ b/setup.js
@@ -5,10 +5,12 @@ var data = require('./data');
 var cwd = process.cwd();
 var sep = path.sep;
 
-exports.init = function(dir) {
+const SQL_ST_DEFAULT = false;
+
+exports.init = function(sqlStatus) {
 
 	if(data.isInit()){
-		throw 'Master, it is initialized previously.';
+		throw 'Master, it is initialized already previously.';
 	}
 
 	var sqlfiles = data.listSqlfiles();
@@ -17,13 +19,15 @@ exports.init = function(dir) {
 		sqlfilemap:sqlfiles
 	};
 	
+	if(!sqlStatus) sqlStatus = SQL_ST_DEFAULT;
+
 	for (var x in sqlfiles) {
 		var pathname = sqlfiles[x],
 			name = pathname.replace(cwd + sep, '');
 		status.sqlfiles.push({
 			name: name,
 			path: pathname,
-			executed: false
+			executed: sqlStatus
 		});
 	}
 


### PR DESCRIPTION
### Purpose of changes

Sometimes we start to use sqldog to manage sql files but  in fact those files have been executed previously. But by default they will set to be not-executed  state when init the directory. So it's necessary to provide an extensional init command to set files as executed state. 

By this changes, user could init the directory and set all files to executed state by following command:

```
sqldog init -se
```
